### PR TITLE
Make zmp directory optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
       <dependency>
         <groupId>org.apache.zookeeper</groupId>
         <artifactId>zookeeper</artifactId>
-        <version>3.4.6</version>
+        <version>3.4.10</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Would it be possible to make this value an optional value? I was looking for something to start zookeeper but not lose data between builds and not require others to install/manage an instance of zookeeper. 